### PR TITLE
lfs config for .fbx files is missing in the .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.zip filter=lfs diff=lfs merge=lfs -text
+*.fbx filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Thank you for making this dataset available!
I noticed that the lfs config for .fbx files was missing in the .gitattributes, so I could not clone the .fbx file together with the repo.
I made a small fix for that, if you find it useful (or maybe that was by design?).
Cheers!